### PR TITLE
chore: add serializers and webhooks to rails stats output

### DIFF
--- a/lib/tasks/stats.rake
+++ b/lib/tasks/stats.rake
@@ -1,0 +1,8 @@
+task stats: :statsetup
+
+task :statsetup do
+  ::STATS_DIRECTORIES.push(
+    %w[Serializers app/serializers],
+    %w[Webhooks app/webhooks]
+  )
+end


### PR DESCRIPTION
## Summary

- Added `lib/tasks/stats.rake` to extend `bin/rails stats` with two directories that were previously missing from the output
- `app/serializers` and `app/webhooks` are now tracked alongside the standard Rails directories

Uses the `STATS_DIRECTORIES.push` / `statsetup` Rake pattern, which is the correct approach for Rails 7.1 (the `Rails::CodeStatistics.register_directory` API is not available until a later Rails version).

## rails stats output

```
+----------------------+--------+--------+---------+---------+-----+-------+
| Name                 |  Lines |    LOC | Classes | Methods | M/C | LOC/M |
+----------------------+--------+--------+---------+---------+-----+-------+
| Controllers          |   1482 |   1127 |      23 |     133 |   5 |     6 |
| Helpers              |     59 |     49 |       0 |       5 |   0 |     7 |
| Jobs                 |    288 |    221 |       3 |       8 |   2 |    25 |
| Models               |    253 |    195 |      12 |      14 |   1 |    11 |
| Mailers              |     41 |     40 |       4 |       3 |   0 |    11 |
| Channels             |      8 |      8 |       2 |       0 |   0 |     0 |
| Views                |   2129 |   1884 |       0 |       0 |   0 |     0 |
| Stylesheets          |   1826 |   1490 |       0 |       0 |   0 |     0 |
| JavaScript           |   1017 |    787 |       0 |      32 |   0 |    22 |
| Libraries            |     61 |     48 |       0 |       0 |   0 |     0 |
| Controller tests     |      0 |      0 |       0 |       0 |   0 |     0 |
| Helper tests         |      0 |      0 |       0 |       0 |   0 |     0 |
| Model tests          |      0 |      0 |       0 |       0 |   0 |     0 |
| Mailer tests         |     11 |      5 |       2 |       0 |   0 |     0 |
| Channel tests        |     13 |      5 |       1 |       0 |   0 |     0 |
| Integration tests    |      0 |      0 |       0 |       0 |   0 |     0 |
| System tests         |      0 |      0 |       0 |       0 |   0 |     0 |
| Serializers          |    132 |    106 |       6 |      17 |   2 |     4 |
| Webhooks             |    108 |     90 |       2 |       8 |   4 |     9 |
+----------------------+--------+--------+---------+---------+-----+-------+
| Total                |   7428 |   6055 |      55 |     220 |   4 |    25 |
+----------------------+--------+--------+---------+---------+-----+-------+
  Code LOC: 6045     Test LOC: 10     Code to Test Ratio: 1:0.0
```

🤖 Co-authored with Claude Code