### PR TITLE
Added Searches: UID & Physical Location

### DIFF
--- a/app/controllers/archive_items_controller.rb
+++ b/app/controllers/archive_items_controller.rb
@@ -70,7 +70,14 @@ class ArchiveItemsController < ApplicationController
     @archive_items = ArchiveItem.all
     @archive_items.each do |item|
       # Sync all tag fields
-      item.update_columns(search_locations: item.location_list.join(', '), search_tags: item.tag_list.join(', '), search_people: item.person_list.join(', '), search_comm_groups: item.comm_group_list.join(', '), search_collections: item.collection_list.join(', '))
+      item.update_columns(
+        search_locations: item.location_list.join(', '),
+        search_tags: item.tag_list.join(', '),
+        search_people: item.person_list.join(', '),
+        search_comm_groups: item.comm_group_list.join(', '),
+        search_collections: item.collection_list.join(', '),
+        search_medium_notes: item.medium_notes.body&.to_plain_text
+      )
     end
   end
 

--- a/app/controllers/archive_items_controller.rb
+++ b/app/controllers/archive_items_controller.rb
@@ -334,6 +334,6 @@ class ArchiveItemsController < ApplicationController
   end
 
   def archive_item_params
-    params.require(:archive_item).permit(:poster_image, :title, :medium, :year, :credit, :location, :tag_list, :location_list, :person_list, :comm_group_list, :collection_list, :date_is_approx, :content_notes, :medium_notes, :medium_photo, :search_tags, :search_locations, :search_people, :search_comm_groups, :search_collections, :created_by, :updated_by, :updated_at, :draft, :featured_item, :content_redirect, :content_files_order, :medium_photos_order, content_files: [], content_files_order: [], :medium_photos => [], medium_photos_order: [], redirect_links_attributes: [:id, :url, :url_label, :_destroy, :position])
+    params.require(:archive_item).permit(:poster_image, :title, :medium, :year, :credit, :physical_location, :tag_list, :location_list, :person_list, :comm_group_list, :collection_list, :date_is_approx, :content_notes, :medium_notes, :medium_photo, :search_tags, :search_locations, :search_people, :search_comm_groups, :search_collections, :created_by, :updated_by, :updated_at, :draft, :featured_item, :content_redirect, :content_files_order, :medium_photos_order, content_files: [], content_files_order: [], :medium_photos => [], medium_photos_order: [], redirect_links_attributes: [:id, :url, :url_label, :_destroy, :position])
   end
 end

--- a/app/jobs/export_archive_items_csv_job.rb
+++ b/app/jobs/export_archive_items_csv_job.rb
@@ -120,7 +120,7 @@ class ExportArchiveItemsCsvJob < ApplicationJob
       item.search_people,
       item.search_locations,
       item.search_tags,
-      item.location,
+      item.physical_location,
       content_notes,
       medium_notes,
       urls,

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -40,6 +40,7 @@ class ArchiveItem < ApplicationRecord
             uid: 'C',
             physical_location: 'C',
             search_collections: 'D',
+            search_medium_notes: 'D',
             created_by: 'D',
             updated_by: 'D',
             redirect_links: 'D'

--- a/app/models/archive_item.rb
+++ b/app/models/archive_item.rb
@@ -37,6 +37,8 @@ class ArchiveItem < ApplicationRecord
             search_comm_groups: 'B',
             search_tags: 'C',
             search_locations: 'C',
+            uid: 'C',
+            physical_location: 'C',
             search_collections: 'D',
             created_by: 'D',
             updated_by: 'D',

--- a/app/views/archive_items/_form.html.erb
+++ b/app/views/archive_items/_form.html.erb
@@ -19,8 +19,8 @@
       </div>
     </div>
     <div class="form-set">
-      <%= form.label :location, "Item's Physical Location" %>
-      <%= form.text_field :location, autocomplete: "off", "data-lpignore": true %>
+      <%= form.label :physical_location, "Item's Physical Location" %>
+      <%= form.text_field :physical_location, autocomplete: "off", "data-lpignore": true %>
     </div>
   </div>
 

--- a/config/initializers/sync_archive_item_search.rb
+++ b/config/initializers/sync_archive_item_search.rb
@@ -1,0 +1,7 @@
+Rails.application.config.after_initialize do
+  ActionText::RichText.after_commit do
+    if record_type == "ArchiveItem" && name == "medium_notes"
+      record.update_column(:search_medium_notes, body&.to_plain_text)
+    end
+  end
+end

--- a/db/migrate/20260514180246_add_uid_and_locationto_cms_ft_search.rb
+++ b/db/migrate/20260514180246_add_uid_and_locationto_cms_ft_search.rb
@@ -1,14 +1,42 @@
 class AddUidAndLocationtoCmsFtSearch < ActiveRecord::Migration[7.1]
   def up
-    remove_index: archive_items, :cms_ft_search
+    rename_column :archive_items, :location, :physical_location
+    remove_index :archive_items, :cms_ft_search
     execute <<~SQL
       ALTER TABLE archive_items DROP COLUMN cms_ft_search;
       ALTER TABLE archive_items ADD COLUMN cms_ft_search tsvector GENERATED ALWAYS AS (
-        setweight(to_tsvector(''))
-      )
+        setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(search_people, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_comm_groups, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_tags, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_locations, '')), 'C') ||
+        setweight(to_tsvector('simple',  COALESCE(uid, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(physical_location, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_collections, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(created_by, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(updated_by, '')), 'D')
+      ) STORED;
+    SQL
+    add_index :archive_items, :cms_ft_search, using: :gin
+
   end
 
   def down
-
+    remove_index :archive_items, :cms_ft_search
+    execute <<~SQL
+      ALTER TABLE archive_items DROP COLUMN cms_ft_search;
+      ALTER TABLE archive_items ADD COLUMN cms_ft_search tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(search_people, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_comm_groups, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_tags, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_locations, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_collections, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(created_by, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(updated_by, '')), 'D')
+      ) STORED;
+    SQL
+    add_index :archive_items, :cms_ft_search, using: :gin
+    rename_column :archive_items, :physical_location, :location
   end
 end

--- a/db/migrate/20260514180246_add_uid_and_locationto_cms_ft_search.rb
+++ b/db/migrate/20260514180246_add_uid_and_locationto_cms_ft_search.rb
@@ -1,0 +1,14 @@
+class AddUidAndLocationtoCmsFtSearch < ActiveRecord::Migration[7.1]
+  def up
+    remove_index: archive_items, :cms_ft_search
+    execute <<~SQL
+      ALTER TABLE archive_items DROP COLUMN cms_ft_search;
+      ALTER TABLE archive_items ADD COLUMN cms_ft_search tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector(''))
+      )
+  end
+
+  def down
+
+  end
+end

--- a/db/migrate/20260522013037_add_search_medium_notes_to_archive_items.rb
+++ b/db/migrate/20260522013037_add_search_medium_notes_to_archive_items.rb
@@ -1,0 +1,44 @@
+class AddSearchMediumNotesToArchiveItems < ActiveRecord::Migration[7.1]
+  def up
+    add_column :archive_items, :search_medium_notes, :text
+    remove_index :archive_items, :cms_ft_search
+    execute <<~SQL
+      ALTER TABLE archive_items DROP COLUMN cms_ft_search;
+      ALTER TABLE archive_items ADD COLUMN cms_ft_search tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(search_people, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_comm_groups, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_tags, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_locations, '')), 'C') ||
+        setweight(to_tsvector('simple',  COALESCE(uid, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(physical_location, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_collections, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(created_by, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(updated_by, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(search_medium_notes, '')), 'D')
+      ) STORED;
+    SQL
+    add_index :archive_items, :cms_ft_search, using: :gin
+  end
+
+  def down
+    remove_index :archive_items, :cms_ft_search
+    execute <<~SQL
+      ALTER TABLE archive_items DROP COLUMN cms_ft_search;
+      ALTER TABLE archive_items ADD COLUMN cms_ft_search tsvector GENERATED ALWAYS AS (
+        setweight(to_tsvector('english', COALESCE(title, '')), 'A') ||
+        setweight(to_tsvector('english', COALESCE(search_people, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_comm_groups, '')), 'B') ||
+        setweight(to_tsvector('english', COALESCE(search_tags, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_locations, '')), 'C') ||
+        setweight(to_tsvector('simple',  COALESCE(uid, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(physical_location, '')), 'C') ||
+        setweight(to_tsvector('english', COALESCE(search_collections, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(created_by, '')), 'D') ||
+        setweight(to_tsvector('english', COALESCE(updated_by, '')), 'D')
+      ) STORED;
+    SQL
+    add_index :archive_items, :cms_ft_search, using: :gin
+    remove_column :archive_items, :search_medium_notes
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict IOX9b12RyT8gCQfWR2uacoBQqrm07GnCMVp88zF7M35voVrrAwYMhAswXlV9tOZ
+\restrict i9glqLOEH2qmxQW0FK49d6FIW58wh1La0quWWosamQ77NG58bsQT61WdOGVQzck
 
 -- Dumped from database version 15.17 (Postgres.app)
 -- Dumped by pg_dump version 15.17 (Postgres.app)
@@ -192,7 +192,8 @@ CREATE TABLE public.archive_items (
     content_redirect boolean DEFAULT false,
     ft_names_search tsvector GENERATED ALWAYS AS ((((setweight(to_tsvector('simple'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char"))) STORED,
     physical_location character varying,
-    cms_ft_search tsvector GENERATED ALWAYS AS ((((((((((setweight(to_tsvector('english'::regconfig, (COALESCE(title, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('english'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(uid, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(physical_location, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_collections, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(created_by, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(updated_by, ''::character varying))::text), 'D'::"char"))) STORED
+    search_medium_notes text,
+    cms_ft_search tsvector GENERATED ALWAYS AS (((((((((((setweight(to_tsvector('english'::regconfig, (COALESCE(title, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('english'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(uid, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(physical_location, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_collections, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(created_by, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(updated_by, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, COALESCE(search_medium_notes, ''::text)), 'D'::"char"))) STORED
 );
 
 
@@ -1160,11 +1161,12 @@ ALTER TABLE ONLY public.active_storage_attachments
 -- PostgreSQL database dump complete
 --
 
-\unrestrict IOX9b12RyT8gCQfWR2uacoBQqrm07GnCMVp88zF7M35voVrrAwYMhAswXlV9tOZ
+\unrestrict i9glqLOEH2qmxQW0FK49d6FIW58wh1La0quWWosamQ77NG58bsQT61WdOGVQzck
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260522013037'),
 ('20260514180246'),
 ('20260409180646'),
 ('20260331225350'),

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict QTeFKgVAjbH5yzxOM9QmvDtZ9E7UDQRdLmgNMyh7l2qkmzp8R4yc4JtfPCHqWz8
+\restrict IOX9b12RyT8gCQfWR2uacoBQqrm07GnCMVp88zF7M35voVrrAwYMhAswXlV9tOZ
 
 -- Dumped from database version 15.17 (Postgres.app)
 -- Dumped by pg_dump version 15.17 (Postgres.app)
@@ -184,7 +184,6 @@ CREATE TABLE public.archive_items (
     search_comm_groups character varying,
     updated_by character varying,
     ft_search tsvector GENERATED ALWAYS AS ((((((setweight(to_tsvector('english'::regconfig, (COALESCE(title, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('english'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_collections, ''::character varying))::text), 'D'::"char"))) STORED,
-    cms_ft_search tsvector GENERATED ALWAYS AS ((((((((setweight(to_tsvector('english'::regconfig, (COALESCE(title, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('english'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_collections, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(created_by, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(updated_by, ''::character varying))::text), 'D'::"char"))) STORED,
     draft boolean DEFAULT false,
     uid character varying,
     featured_item boolean DEFAULT false,
@@ -192,7 +191,8 @@ CREATE TABLE public.archive_items (
     medium_photos_order text[] DEFAULT '{}'::text[],
     content_redirect boolean DEFAULT false,
     ft_names_search tsvector GENERATED ALWAYS AS ((((setweight(to_tsvector('simple'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char"))) STORED,
-    location character varying
+    physical_location character varying,
+    cms_ft_search tsvector GENERATED ALWAYS AS ((((((((((setweight(to_tsvector('english'::regconfig, (COALESCE(title, ''::character varying))::text), 'A'::"char") || setweight(to_tsvector('english'::regconfig, (COALESCE(search_people, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_comm_groups, ''::character varying))::text), 'B'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_tags, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_locations, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('simple'::regconfig, (COALESCE(uid, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(physical_location, ''::character varying))::text), 'C'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(search_collections, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(created_by, ''::character varying))::text), 'D'::"char")) || setweight(to_tsvector('english'::regconfig, (COALESCE(updated_by, ''::character varying))::text), 'D'::"char"))) STORED
 );
 
 
@@ -1160,11 +1160,12 @@ ALTER TABLE ONLY public.active_storage_attachments
 -- PostgreSQL database dump complete
 --
 
-\unrestrict QTeFKgVAjbH5yzxOM9QmvDtZ9E7UDQRdLmgNMyh7l2qkmzp8R4yc4JtfPCHqWz8
+\unrestrict IOX9b12RyT8gCQfWR2uacoBQqrm07GnCMVp88zF7M35voVrrAwYMhAswXlV9tOZ
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260514180246'),
 ('20260409180646'),
 ('20260331225350'),
 ('20251023203900'),


### PR DESCRIPTION
## Summary

- Renames the `location` column to `physical_location` on `archive_items` for semantic clarity (the form label already read "Item's Physical Location")
- Rebuilds the `cms_ft_search` generated tsvector column to include `uid` (indexed with the `simple` dictionary to preserve exact numeric segments) and `physical_location` (indexed with `english`)
- Adds a `search_medium_notes` text column to `archive_items` as a denormalized plain-text copy of the `medium_notes` Action Text field, included in `cms_ft_search` at weight D
- Adds an initializer that hooks into `ActionText::RichText` to keep `search_medium_notes` in sync automatically on every save
- Updates `sync_search_strings` to include `search_medium_notes` in manual re-sync
- Updates all references to the renamed column: model `pg_search_scope`, controller strong params, form view, and CSV export job


## Test plan

- [x] Run `rails db:migrate` and confirm it completes without error
- [x] Verify the `physical_location` column exists and `location` is gone: `ArchiveItem.column_names`
- [x] Confirm physical location field saves and displays correctly on an archive item edit form
- [x] Search for a known UID in the CMS archive item search and confirm the item is returned
- [x] Search for a known physical location value and confirm results are returned
- [x] Export CSV and confirm the `physical_location` column is populated correctly
- [x] Roll back (`rails db:rollback STEP=1`) and confirm the tsvector and column name are restored
- [x] - [ ] Backfill existing records via console and confirm pre-existing items with medium notes become searchable:
  ```ruby
  ActionText::RichText.where(record_type: "ArchiveItem", name: "medium_notes").find_each do |rt|
    rt.record.update_column(:search_medium_notes, rt.body&.to_plain_text)
  end
