### PR TITLE
updated sync_archive_items_search.rb to only run on create and update…

### DIFF
--- a/config/initializers/sync_archive_item_search.rb
+++ b/config/initializers/sync_archive_item_search.rb
@@ -1,5 +1,5 @@
 Rails.application.config.after_initialize do
-  ActionText::RichText.after_commit do
+  ActionText::RichText.after_commit on: [:create, :update] do
     if record_type == "ArchiveItem" && name == "medium_notes"
       record.update_column(:search_medium_notes, body&.to_plain_text)
     end


### PR DESCRIPTION
## Summary

- Scoped `after_commit` callback in `sync_archive_item_search.rb` to `[:create, :update]` only
- Fixes "cannot update a destroyed record" error thrown when deleting an `ArchiveItem`, which triggered the callback on its associated `ActionText::RichText` records during destroy

## Test plan

- [x] Delete an `ArchiveItem` and confirm no error is raised
- [x] Create an `ArchiveItem` with `medium_notes` and confirm `search_medium_notes` is populated
- [x] Update `medium_notes` on an existing `ArchiveItem` and confirm `search_medium_notes` reflects the change