### PR TITLE
pushing changes to staging to test s3 upload

### DIFF
--- a/app/javascript/controllers/dropzone_controller.js
+++ b/app/javascript/controllers/dropzone_controller.js
@@ -29,6 +29,49 @@ function insertAfter(el, referenceNode) {
   return referenceNode.parentNode.insertBefore(el, referenceNode.nextSibling);
 }
 
+// Shared across every dropzone_controller instance on the page (content files,
+// format photos, etc. each get their own instance but submit the same form), so
+// the count has to live outside any single controller.
+const pendingUploadsByForm = new WeakMap();
+
+function findSubmitButton(form) {
+  return findElement(form, "input[type=submit], button[type=submit]");
+}
+
+function uploadStarted(form) {
+  if (!form) return;
+  const count = (pendingUploadsByForm.get(form) || 0) + 1;
+  pendingUploadsByForm.set(form, count);
+  if (count !== 1) return;
+
+  const button = findSubmitButton(form);
+  if (!button) return;
+  button.disabled = true;
+  button.dataset.uploadingText ||= "Uploading files…";
+  button.dataset.originalText = button.tagName === "INPUT" ? button.value : button.textContent;
+  if (button.tagName === "INPUT") {
+    button.value = button.dataset.uploadingText;
+  } else {
+    button.textContent = button.dataset.uploadingText;
+  }
+}
+
+function uploadFinished(form) {
+  if (!form) return;
+  const count = Math.max((pendingUploadsByForm.get(form) || 1) - 1, 0);
+  pendingUploadsByForm.set(form, count);
+  if (count !== 0) return;
+
+  const button = findSubmitButton(form);
+  if (!button || button.dataset.originalText === undefined) return;
+  button.disabled = false;
+  if (button.tagName === "INPUT") {
+    button.value = button.dataset.originalText;
+  } else {
+    button.textContent = button.dataset.originalText;
+  }
+}
+
 export default class extends Controller {
   static targets = ["input", "previewsContainer"]
 
@@ -133,7 +176,9 @@ class DirectUploadController {
   start() {
     this.file.controller = this;
     this.hiddenInput = this.createHiddenInput();
+    uploadStarted(this.source.form);
     this.directUpload.create((error, attributes) => {
+      uploadFinished(this.source.form);
       if (error) {
         removeElement(this.hiddenInput);
         this.emitDropzoneError(error);

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,11 @@ module WafAdmin10
 
     config.active_job.queue_adapter = :sidekiq
 
+    # Default (5 minutes) is too short for large direct-to-S3 video uploads on slow
+    # connections; the presigned PUT URL expires mid-upload and the whole file has
+    # to be re-uploaded from scratch.
+    config.active_storage.service_urls_expire_in = 1.hour
+
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
## Summary

Staff reported that video uploads (e.g. a 667 MB .mp4) on the archive item form take
repeated attempts and are unreliable. Uploads go browser-direct to S3 via a custom
Dropzone/ActiveStorage integration, which bypasses two protections Rails normally
provides out of the box:

- **Presigned upload URLs expired after 5 minutes** (Rails default, never
  overridden). Large files on typical connections don't finish the single,
  non-resumable PUT in that window, so the URL expires mid-upload and the whole
  file has to be re-uploaded from scratch.
- **Nothing blocked form submission while an upload was still in flight.** The form
  references a `direct-uploads` Stimulus controller intended to guard this, but
  that controller was never actually implemented — so submitting early (easy to do
  on a multi-minute upload with no lock) silently saves the archive item without
  the attachment, which looks exactly like a failed upload.

## Changes

- `config/application.rb`: extend `active_storage.service_urls_expire_in` from the
  5-minute default to 1 hour, giving large uploads enough headroom on slower
  connections.
- `app/javascript/controllers/dropzone_controller.js`: track in-flight direct
  uploads per form (shared across the Content Files / Format Photos dropzone
  instances via a `WeakMap`) and disable+relabel the submit button
  ("Uploading files…") until all uploads for that form complete, then re-enable it.

## Out of scope

Retry-on-failure and chunked/multipart uploads would further improve reliability
for very large files but are bigger changes — noted as follow-up if uploads are
still flaky after this.

## Test plan

- [x] Upload a large (~600+ MB) video as a content file on a new/existing archive
      item; confirm submit is disabled with "Uploading files…" during the upload
      and re-enabled after it completes.
- [x] Confirm the archive item saves with the video attached after the upload
      finishes.
- [x] Verify `rails runner 'puts ActiveStorage.service_urls_expire_in'` returns
      `3600` in the target environment.
- [x] Spot-check that Format Photos and Poster Image uploads still work normally.
