### PR TITLE
Location serializer

### DIFF
--- a/app/serializers/archive_item_serializer.rb
+++ b/app/serializers/archive_item_serializer.rb
@@ -3,10 +3,14 @@ class ArchiveItemSerializer < ActiveModel::Serializer
 
   attributes :id, :medium, :year, :title, :content_notes, :credit, :draft, :poster_url, :content_file_urls, :content_file_names, :medium_photo_urls, :medium_photos_file_names, :collections, :credit, :featured_item, :redirect_links, :content_redirect, :uid
   has_many :tags, embed: :id, include: true
-  has_many :locations, embed: :id, include: true
+  has_many :locations
   has_many :comm_groups, embed: :id, include: true
   has_many :people, embed: :id, include: true
   has_many :redirect_links, include: true
+
+  def locations
+    Location.where(name: object.location_list)
+  end
 
   def poster_url
     return nil unless object.poster_image.attached?

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,0 +1,3 @@
+class LocationSerializer < ActiveModel::Serializer
+  attributes :id, :name, :lat, :lng
+end

--- a/app/serializers/location_serializer.rb
+++ b/app/serializers/location_serializer.rb
@@ -1,3 +1,3 @@
 class LocationSerializer < ActiveModel::Serializer
-  attributes :id, :name, :lat, :lng
+  attributes :id, :name, :lat, :lng, :description
 end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,4 +1,4 @@
-\restrict i9glqLOEH2qmxQW0FK49d6FIW58wh1La0quWWosamQ77NG58bsQT61WdOGVQzck
+\restrict 5nw82sqnwLOPPhxEx0MJEZCxn7sTnBCpgDaIOd0nJPsmFmKtBdarKfWHTimS82w
 
 -- Dumped from database version 15.17 (Postgres.app)
 -- Dumped by pg_dump version 15.17 (Postgres.app)
@@ -250,40 +250,6 @@ ALTER SEQUENCE public.archive_tags_id_seq OWNED BY public.archive_tags.id;
 
 
 --
--- Name: carousel_slides; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.carousel_slides (
-    id bigint NOT NULL,
-    title character varying,
-    description text,
-    link character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    "position" integer
-);
-
-
---
--- Name: carousel_slides_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.carousel_slides_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: carousel_slides_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.carousel_slides_id_seq OWNED BY public.carousel_slides.id;
-
-
---
 -- Name: collections; Type: TABLE; Schema: public; Owner: -
 --
 
@@ -383,89 +349,6 @@ CREATE SEQUENCE public.locations_id_seq
 --
 
 ALTER SEQUENCE public.locations_id_seq OWNED BY public.locations.id;
-
-
---
--- Name: page_carousel_slides; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.page_carousel_slides (
-    id bigint NOT NULL,
-    title character varying,
-    description text,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    collections character varying,
-    page character varying,
-    "position" integer,
-    year integer,
-    comm_groups character varying,
-    medium character varying,
-    people character varying,
-    locations character varying,
-    tags character varying
-);
-
-
---
--- Name: page_carousel_slides_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.page_carousel_slides_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: page_carousel_slides_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.page_carousel_slides_id_seq OWNED BY public.page_carousel_slides.id;
-
-
---
--- Name: pages; Type: TABLE; Schema: public; Owner: -
---
-
-CREATE TABLE public.pages (
-    id bigint NOT NULL,
-    title character varying,
-    description text,
-    tag character varying,
-    created_at timestamp(6) without time zone NOT NULL,
-    updated_at timestamp(6) without time zone NOT NULL,
-    slug character varying,
-    comm_groups character varying,
-    ctatext character varying,
-    ctalink character varying,
-    subtitle text,
-    donate_url character varying,
-    collection character varying,
-    draft boolean DEFAULT false,
-    mail_list_url character varying
-);
-
-
---
--- Name: pages_id_seq; Type: SEQUENCE; Schema: public; Owner: -
---
-
-CREATE SEQUENCE public.pages_id_seq
-    START WITH 1
-    INCREMENT BY 1
-    NO MINVALUE
-    NO MAXVALUE
-    CACHE 1;
-
-
---
--- Name: pages_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
---
-
-ALTER SEQUENCE public.pages_id_seq OWNED BY public.pages.id;
 
 
 --
@@ -694,13 +577,6 @@ ALTER TABLE ONLY public.archive_tags ALTER COLUMN id SET DEFAULT nextval('public
 
 
 --
--- Name: carousel_slides id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.carousel_slides ALTER COLUMN id SET DEFAULT nextval('public.carousel_slides_id_seq'::regclass);
-
-
---
 -- Name: collections id; Type: DEFAULT; Schema: public; Owner: -
 --
 
@@ -719,20 +595,6 @@ ALTER TABLE ONLY public.comm_groups ALTER COLUMN id SET DEFAULT nextval('public.
 --
 
 ALTER TABLE ONLY public.locations ALTER COLUMN id SET DEFAULT nextval('public.locations_id_seq'::regclass);
-
-
---
--- Name: page_carousel_slides id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.page_carousel_slides ALTER COLUMN id SET DEFAULT nextval('public.page_carousel_slides_id_seq'::regclass);
-
-
---
--- Name: pages id; Type: DEFAULT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pages ALTER COLUMN id SET DEFAULT nextval('public.pages_id_seq'::regclass);
 
 
 --
@@ -827,14 +689,6 @@ ALTER TABLE ONLY public.archive_tags
 
 
 --
--- Name: carousel_slides carousel_slides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.carousel_slides
-    ADD CONSTRAINT carousel_slides_pkey PRIMARY KEY (id);
-
-
---
 -- Name: collections collections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
 --
 
@@ -856,22 +710,6 @@ ALTER TABLE ONLY public.comm_groups
 
 ALTER TABLE ONLY public.locations
     ADD CONSTRAINT locations_pkey PRIMARY KEY (id);
-
-
---
--- Name: page_carousel_slides page_carousel_slides_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.page_carousel_slides
-    ADD CONSTRAINT page_carousel_slides_pkey PRIMARY KEY (id);
-
-
---
--- Name: pages pages_pkey; Type: CONSTRAINT; Schema: public; Owner: -
---
-
-ALTER TABLE ONLY public.pages
-    ADD CONSTRAINT pages_pkey PRIMARY KEY (id);
 
 
 --
@@ -1161,11 +999,12 @@ ALTER TABLE ONLY public.active_storage_attachments
 -- PostgreSQL database dump complete
 --
 
-\unrestrict i9glqLOEH2qmxQW0FK49d6FIW58wh1La0quWWosamQ77NG58bsQT61WdOGVQzck
+\unrestrict 5nw82sqnwLOPPhxEx0MJEZCxn7sTnBCpgDaIOd0nJPsmFmKtBdarKfWHTimS82w
 
 SET search_path TO "$user", public;
 
 INSERT INTO "schema_migrations" (version) VALUES
+('20260528004257'),
 ('20260522013037'),
 ('20260514180246'),
 ('20260409180646'),


### PR DESCRIPTION
## Branch: `location-serializer`

### Summary
Adds a dedicated `LocationSerializer` and updates `ArchiveItemSerializer` to use it for nested location data instead of the default `has_many` embed.

### Changes

**`app/serializers/location_serializer.rb`** (new)
- Serializes `id`, `name`, `lat`, `lng`, `description` for `Location` records.

**`app/serializers/archive_item_serializer.rb`**
- Changed `has_many :locations, embed: :id, include: true` to `has_many :locations`, now backed by a custom `locations` method that resolves `Location.where(name: object.location_list)` instead of relying on the default association/embed.

**`db/structure.sql`**
- Incidental schema drift picked up from merging `main` (e.g. removal of `carousel_slides` table/sequence) — not part of this branch's feature work.

### Commits
- `383bc1d` wip: location serializer
- `1fa2e07` Merge branch 'main' into location-serializer
- `d2c5516` Merge branch 'main' into location-serializer
- `02c1b00` description added to location serializer